### PR TITLE
[A11Y] HTML text traits

### DIFF
--- a/Sample/Sample/Examples/HTMLTextView.swift
+++ b/Sample/Sample/Examples/HTMLTextView.swift
@@ -13,12 +13,14 @@ struct HTMLTextView: View {
                         RoundedCorner(radius: 12)
                             .strokeBorder(.tertiary)
                     }
+                    .htmlAccessibilityTraits(.header)
                 HTMLText(html: "<h2>First test</h2>")
                     .padding()
                     .background {
                         RoundedCorner(radius: 12)
                             .strokeBorder(.tertiary)
                     }
+                    .htmlAccessibilityTraits(.header)
                 HTMLText(html: "<p>A <b>paragraph</b>. It's longer, and wider, and better. It should be on 2 lines, hopefully. </p>")
                     .padding()
                     .background {
@@ -31,6 +33,7 @@ struct HTMLTextView: View {
                         RoundedCorner(radius: 12)
                             .strokeBorder(.tertiary)
                     }
+                    .htmlAccessibilityTraits(.header)
                 HTMLText(html: "<i>This is a lonely italic line. </i>")
                     .padding()
                     .background {

--- a/Sources/SwiftUI-Utils/View/HTMLText/HTMLText+Environment.swift
+++ b/Sources/SwiftUI-Utils/View/HTMLText/HTMLText+Environment.swift
@@ -7,6 +7,7 @@ extension EnvironmentValues {
     @Entry var htmlFont: HTMLFont = .system
     @Entry var htmlLineSpacing: CGFloat?
     @Entry var htmlLineBreakMode: NSLineBreakMode = .byTruncatingTail
+    @Entry var htmlAccessibilityTraits: UIAccessibilityTraits = .staticText
 }
 
 extension View {
@@ -33,5 +34,9 @@ extension View {
 
     public func htmlLineBreakMode(_ mode: NSLineBreakMode) -> some View {
         environment(\.htmlLineBreakMode, mode)
+    }
+
+    public func htmlAccessibilityTraits(_ traits: UIAccessibilityTraits) -> some View {
+        environment(\.htmlAccessibilityTraits, traits)
     }
 }

--- a/Sources/SwiftUI-Utils/View/HTMLText/HTMLText.swift
+++ b/Sources/SwiftUI-Utils/View/HTMLText/HTMLText.swift
@@ -24,6 +24,7 @@ public struct HTMLText: UIViewRepresentable {
     @Environment(\.htmlFont) var font
     @Environment(\.htmlLineSpacing) var lineSpacing
     @Environment(\.htmlLineBreakMode) var lineBreakMode
+    @Environment(\.htmlAccessibilityTraits) var accessibilityTraits
 
     let html: String
 
@@ -42,7 +43,7 @@ public struct HTMLText: UIViewRepresentable {
         view.textContainer.lineBreakMode = lineBreakMode
         view.textContainer.maximumNumberOfLines = lineLimit ?? 0
         view.textContainerInset = .zero
-        view.accessibilityTraits = .staticText
+        view.accessibilityTraits = accessibilityTraits
         view.delegate = context.coordinator
         return view
     }
@@ -128,7 +129,7 @@ extension HTMLText {
                 .characterEncoding: String.Encoding.utf8.rawValue,
             ]
             let attributes: [NSAttributedString.Key: Any] = [
-                .kern: kerning
+                .kern: kerning,
             ]
 
             let attributedString = try NSMutableAttributedString(data: data, options: options, documentAttributes: nil)


### PR DESCRIPTION
Ajout du support pour les _traits_ d'accessibilité.

Malheureusement, SwiftUI ne propage pas les siens vers les vues UIKit.
