### PR TITLE
Add readVisibleItems scrollview viewModifiers

### DIFF
--- a/Sample/Sample/Examples/ReadVisibleItemsSampleView.swift
+++ b/Sample/Sample/Examples/ReadVisibleItemsSampleView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import SwiftUIUtils
+
+struct ReadVisibleItemsSampleView: View {
+    private let sampleItems = (0 ..< 100).map { "\($0)" }
+
+    @State private var visibleItems: [String] = []
+
+    var body: some View {
+        VStack {
+            Text("Visible items:")
+            Text("\(visibleItems.joined(separator: ", "))")
+
+            ScrollView {
+                LazyVStack {
+                    ForEach(sampleItems, id: \.self) { item in
+                        Text(item)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(.mint, in: RoundedRectangle(cornerRadius: 8))
+                            .setLoadedItem(item)
+                    }
+                }
+                .padding()
+            }
+            .readVisibleItems($visibleItems)
+        }
+    }
+}
+
+#Preview {
+    ReadVisibleItemsSampleView()
+}

--- a/Sample/Sample/Examples/ReadVisibleItemsSampleView.swift
+++ b/Sample/Sample/Examples/ReadVisibleItemsSampleView.swift
@@ -18,12 +18,12 @@ struct ReadVisibleItemsSampleView: View {
                             .frame(maxWidth: .infinity)
                             .padding()
                             .background(.mint, in: RoundedRectangle(cornerRadius: 8))
-                            .setLoadedItem(item)
+                            .visibleViewIdentifier(item)
                     }
                 }
                 .padding()
             }
-            .readVisibleItems($visibleItems)
+            .onVisibleViewIdentifiersChange($visibleItems)
         }
     }
 }

--- a/Sources/SwiftUI-Utils/ScrollView/VisibleViewGetters.swift
+++ b/Sources/SwiftUI-Utils/ScrollView/VisibleViewGetters.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+extension View {
+    public func setLoadedItem(_ itemId: String) -> some View {
+        anchorPreference(
+            key: LoadedItemsPreferenceKey.self,
+            value: .bounds,
+            transform: { anchor in
+                [.init(itemId: itemId, bounds: anchor)]
+            }
+        )
+    }
+}
+
+extension ScrollView {
+    public func readVisibleItems(_ items: @escaping ([String]) -> Void) -> some View {
+        backgroundPreferenceValue(LoadedItemsPreferenceKey.self) { loadedItems in
+            ReadVisibleItemView(loadedItems: loadedItems)
+        }
+        .onPreferenceChange(VisibleItemsPreferenceKey.self) {
+            items($0)
+        }
+    }
+
+    public func readVisibleItems(_ items: Binding<[String]>) -> some View {
+        backgroundPreferenceValue(LoadedItemsPreferenceKey.self) { loadedItems in
+            ReadVisibleItemView(loadedItems: loadedItems)
+        }
+        .onPreferenceChange(VisibleItemsPreferenceKey.self) {
+            items.wrappedValue = $0
+        }
+    }
+}
+
+private struct LoadedItemsPreferenceKeyPayload {
+    let itemId: String
+    let bounds: Anchor<CGRect>
+}
+
+private struct LoadedItemsPreferenceKey: PreferenceKey {
+    static var defaultValue: [LoadedItemsPreferenceKeyPayload] = []
+
+    static func reduce(value: inout Value, nextValue: () -> Value) {
+        value.append(contentsOf: nextValue())
+    }
+}
+
+private struct VisibleItemsPreferenceKey: PreferenceKey {
+    static var defaultValue: [String] = []
+
+    static func reduce(value: inout Value, nextValue: () -> Value) {
+        value.append(contentsOf: nextValue())
+    }
+}
+
+private struct ReadVisibleItemView: View {
+    let loadedItems: [LoadedItemsPreferenceKeyPayload]
+
+    var body: some View {
+        GeometryReader { proxy in
+            Color.clear.preference(
+                key: VisibleItemsPreferenceKey.self,
+                value: loadedItems.visibleItemIds(in: proxy)
+            )
+        }
+    }
+}
+
+extension Collection<LoadedItemsPreferenceKeyPayload> {
+    fileprivate func visibleItemIds(in proxy: GeometryProxy) -> [String] {
+        let localFrame = proxy.frame(in: .local)
+        return compactMap { item in
+            localFrame.intersects(proxy[item.bounds]) ? item.itemId : nil
+        }
+    }
+}

--- a/Sources/SwiftUI-Utils/ScrollView/VisibleViewGetters.swift
+++ b/Sources/SwiftUI-Utils/ScrollView/VisibleViewGetters.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension View {
-    public func setLoadedItem(_ itemId: String) -> some View {
+    public func visibleViewIdentifier(_ itemId: String) -> some View {
         anchorPreference(
             key: LoadedItemsPreferenceKey.self,
             value: .bounds,
@@ -13,7 +13,7 @@ extension View {
 }
 
 extension ScrollView {
-    public func readVisibleItems(_ items: @escaping ([String]) -> Void) -> some View {
+    public func onVisibleViewIdentifiersChange(_ items: @escaping ([String]) -> Void) -> some View {
         backgroundPreferenceValue(LoadedItemsPreferenceKey.self) { loadedItems in
             ReadVisibleItemView(loadedItems: loadedItems)
         }
@@ -22,11 +22,8 @@ extension ScrollView {
         }
     }
 
-    public func readVisibleItems(_ items: Binding<[String]>) -> some View {
-        backgroundPreferenceValue(LoadedItemsPreferenceKey.self) { loadedItems in
-            ReadVisibleItemView(loadedItems: loadedItems)
-        }
-        .onPreferenceChange(VisibleItemsPreferenceKey.self) {
+    public func onVisibleViewIdentifiersChange(_ items: Binding<[String]>) -> some View {
+        onVisibleViewIdentifiersChange {
             items.wrappedValue = $0
         }
     }


### PR DESCRIPTION
## 📖 Description et motivation

Dans le but de pouvoir lire les éléments couramment visible dans une scrollview.

On ajoute deux nouveaux `ViewModifier`:
- `visibleViewIdentifier(_ itemId: String)`: update une preference key avec toutes les vues présentement chargée en mémoire dans la scrollview
- `onVisibleViewIdentifiersChange(_ items: @escaping ([String]) -> Void)`: reçoit via une autre preference key la liste des vues en mémoire qui sont présentement visibles dans le frame de la scrollview.

## 🎉 Résultat

https://github.com/user-attachments/assets/eeb02a40-c305-409e-a006-7d578cf7c5bb
