### PR TITLE
Refactor HTMLText

### DIFF
--- a/Sample/Sample.xcodeproj/project.pbxproj
+++ b/Sample/Sample.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		6A2B15172D8B68C50084537A /* HTMLText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A2B15162D8B68C00084537A /* HTMLText.swift */; };
 		6A2B151B2D8C6B520084537A /* HTMLText+Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A2B151A2D8C6B4A0084537A /* HTMLText+Environment.swift */; };
 		6A2B151F2D8C70840084537A /* HTMLTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A2B151E2D8C70800084537A /* HTMLTextView.swift */; };
+		B59973262E9FE8B3008362FA /* HTMLTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59973252E9FE8AE008362FA /* HTMLTransformer.swift */; };
 		E1316F472AFE839000232575 /* SampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1316F462AFE839000232575 /* SampleApp.swift */; };
 		E1316F492AFE839000232575 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1316F482AFE839000232575 /* RootView.swift */; };
 		E1316F4B2AFE839100232575 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E1316F4A2AFE839100232575 /* Assets.xcassets */; };
@@ -46,6 +47,7 @@
 		6A2B15162D8B68C00084537A /* HTMLText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLText.swift; sourceTree = "<group>"; };
 		6A2B151A2D8C6B4A0084537A /* HTMLText+Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTMLText+Environment.swift"; sourceTree = "<group>"; };
 		6A2B151E2D8C70800084537A /* HTMLTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLTextView.swift; sourceTree = "<group>"; };
+		B59973252E9FE8AE008362FA /* HTMLTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLTransformer.swift; sourceTree = "<group>"; };
 		E10884272BD062E500C7E222 /* SwiftUI-Utils.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = "SwiftUI-Utils.podspec"; path = "../../SwiftUI-Utils.podspec"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		E1316F432AFE839000232575 /* Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1316F462AFE839000232575 /* SampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleApp.swift; sourceTree = "<group>"; };
@@ -102,6 +104,7 @@
 		6A2B15192D8C6B2A0084537A /* HTMLText */ = {
 			isa = PBXGroup;
 			children = (
+				B59973252E9FE8AE008362FA /* HTMLTransformer.swift */,
 				6A2B15162D8B68C00084537A /* HTMLText.swift */,
 				6A2B151A2D8C6B4A0084537A /* HTMLText+Environment.swift */,
 			);
@@ -334,6 +337,7 @@
 				E1A52D392B026BEF008A2B9A /* PinTopView.swift in Sources */,
 				6A2B151F2D8C70840084537A /* HTMLTextView.swift in Sources */,
 				E1316F7F2AFEA23700232575 /* PinTopModifier.swift in Sources */,
+				B59973262E9FE8B3008362FA /* HTMLTransformer.swift in Sources */,
 				E16CE9352B90BC9A007CCA01 /* OnVisibleModifier.swift in Sources */,
 				E1316F942AFEB30C00232575 /* ScrollViewBackport.swift in Sources */,
 				E1A52D362B026513008A2B9A /* OpacityButtonStyle.swift in Sources */,

--- a/Sample/Sample/Examples/HTMLTextView.swift
+++ b/Sample/Sample/Examples/HTMLTextView.swift
@@ -68,12 +68,12 @@ struct HTMLTextView: View {
             .htmlForegroundColor(.secondary)
             .htmlKerning(0)
             .htmlLineSpacing(8)
-            .environment(\.openURL, OpenURLAction { url in
+            .htmlLineBreakMode(.byWordWrapping)
+            .onHTMLOpenURL { url in
                 withAnimation(.snappy) {
                     urlToOpen = url
                 }
-                return .handled
-            })
+            }
         }
         .safeAreaInset(edge: .bottom) {
             if let urlToOpen {

--- a/Sources/SwiftUI-Utils/FrameGetters/FrameGetters.swift
+++ b/Sources/SwiftUI-Utils/FrameGetters/FrameGetters.swift
@@ -49,6 +49,39 @@ public extension View {
                 frame.wrappedValue = $0
             }
     }
+    
+    func read(
+        _ keyPath: KeyPath<CGRect, CGFloat>,
+        in coordinateSpace: CoordinateSpace = .local,
+        _ reader: @escaping (CGFloat) -> Void
+    ) -> some View {
+        background(SingleDimensionGetter(coordinateSpace: coordinateSpace, keyPath: keyPath))
+            .onPreferenceChange(SingleDimensionPreferenceKey.self) {
+                reader($0)
+            }
+    }
+    
+    func read(
+        _ keyPath: KeyPath<CGRect, CGFloat>,
+        in coordinateSpace: CoordinateSpace = .local,
+        _ dimension: Binding<CGFloat>
+    ) -> some View {
+        background(SingleDimensionGetter(coordinateSpace: coordinateSpace, keyPath: keyPath))
+            .onPreferenceChange(SingleDimensionPreferenceKey.self) {
+                dimension.wrappedValue = $0
+            }
+    }
+    
+    func read(
+        _ keyPath: KeyPath<CGRect, CGFloat>,
+        in coordinateSpace: CoordinateSpace = .local,
+        _ dimension: Binding<CGFloat?>
+    ) -> some View {
+        background(SingleDimensionGetter(coordinateSpace: coordinateSpace, keyPath: keyPath))
+            .onPreferenceChange(SingleDimensionPreferenceKey.self) {
+                dimension.wrappedValue = $0
+            }
+    }
 }
 
 private struct FramePreferenceKey: PreferenceKey {
@@ -67,6 +100,26 @@ private struct FrameGetter: View {
             Color.clear.preference(
                 key: FramePreferenceKey.self,
                 value: geometry.frame(in: coordinateSpace)
+            )
+        }
+    }
+}
+
+private struct SingleDimensionPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = .zero
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { }
+}
+
+private struct SingleDimensionGetter: View {
+    let coordinateSpace: CoordinateSpace
+    let keyPath: KeyPath<CGRect, CGFloat>
+
+    var body: some View {
+        GeometryReader { geometry in
+            Color.clear.preference(
+                key: SingleDimensionPreferenceKey.self,
+                value: geometry.frame(in: coordinateSpace)[keyPath: keyPath]
             )
         }
     }

--- a/Sources/SwiftUI-Utils/View/HTMLText/HTMLText+Environment.swift
+++ b/Sources/SwiftUI-Utils/View/HTMLText/HTMLText+Environment.swift
@@ -9,6 +9,20 @@ extension EnvironmentValues {
     @Entry var htmlLineBreakMode: NSLineBreakMode = .byTruncatingTail
     @Entry var htmlAccessibilityTraits: UIAccessibilityTraits = .staticText
     @Entry var htmlTextAlignment: NSTextAlignment = .natural
+    @Entry var htmlOpenURL: HTMLOpenURLAction? = nil
+}
+
+struct HTMLOpenURLAction: Equatable {
+    let id = UUID()
+    let handler: (URL) -> Void
+    
+    func callAsFunction(_ url: URL) {
+        handler(url)
+    }
+
+    static func == (lhs: HTMLOpenURLAction, rhs: HTMLOpenURLAction) -> Bool {
+        lhs.id == rhs.id
+    }
 }
 
 extension View {
@@ -43,5 +57,9 @@ extension View {
 
     public func htmlTextAlignment(_ textAlignment: NSTextAlignment) -> some View {
         environment(\.htmlTextAlignment, textAlignment)
+    }
+    
+    public func onHTMLOpenURL(_ perform: @escaping (URL) -> Void) -> some View {
+        environment(\.htmlOpenURL, HTMLOpenURLAction(handler: perform))
     }
 }

--- a/Sources/SwiftUI-Utils/View/HTMLText/HTMLTransformer.swift
+++ b/Sources/SwiftUI-Utils/View/HTMLText/HTMLTransformer.swift
@@ -1,0 +1,100 @@
+import Foundation
+import os
+
+struct HTMLStyleSheet {
+    var font: HTMLFont = .system
+    var lineSpacing: CGFloat?
+    var kerning: CGFloat = 0
+}
+
+class HTMLTransformer: ObservableObject {
+    private let logger = Logger(subsystem: "HTMLText", category: "Transformer")
+    
+    @Published var html: NSAttributedString = NSAttributedString(string: "")
+    
+    var style: HTMLStyleSheet = HTMLStyleSheet() {
+        didSet { update(html: rawHTML, using: style) }
+    }
+    var rawHTML: String = "" {
+        didSet { update(html: rawHTML, using: style) }
+    }
+    
+    private func update(html string: String, using style: HTMLStyleSheet) {
+        guard !string.isEmpty else {
+            return
+        }
+        
+        let formatter = HtmlStringToAttributedStringFormatter(style: style)
+        do {
+            html = try formatter.format(html: string) ?? NSAttributedString(string: "")
+        } catch {
+            logger.warning("\(error.localizedDescription)")
+            html = NSAttributedString(string: "")
+        }
+    }
+}
+
+private struct HtmlStringToAttributedStringFormatter {
+    let style: HTMLStyleSheet
+
+    func format(html string: String) throws -> NSAttributedString? {
+        guard
+            !string.isEmpty,
+            let data = embedHTML(string).data(using: .utf8)
+        else { return nil }
+
+        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+            .documentType: NSAttributedString.DocumentType.html,
+            .characterEncoding: String.Encoding.utf8.rawValue,
+        ]
+        let attributes: [NSAttributedString.Key: Any] = [
+            .kern: style.kerning,
+        ]
+
+        let attributedString = try NSMutableAttributedString(data: data, options: options, documentAttributes: nil)
+        let range = NSRange(location: 0, length: attributedString.length)
+        attributedString.addAttributes(attributes, range: range)
+        attributedString.enumerateAttribute(.link, in: range) { value, range, _ in
+            guard value != nil else { return }
+            attributedString.removeAttribute(.underlineStyle, range: range)
+        }
+        return attributedString.trimmingTrailingCharacters(in: .newlines)
+    }
+    
+    private func embedHTML(_ html: String) -> String {
+        """
+        <html>
+        <head>
+            <style>
+                body {
+                    font-family: \(style.font.name.map { "\($0), " } ?? "")'-apple-system';
+                    font-size: \(style.font.size);
+                    line-height: \(style.lineSpacing.map { "\($0)px" } ?? "normal");
+                    -webkit-text-size-adjust: none;
+                    margin: 0;
+                }
+            </style>
+        </head>
+        <body>
+            \(html)
+        </body>
+        </html>
+        """
+    }
+}
+
+extension NSMutableAttributedString {
+
+    func trimmingTrailingCharacters(in characters: CharacterSet) -> NSMutableAttributedString {
+        guard !string.isEmpty else {
+            return self
+        }
+
+        let attributedString = NSMutableAttributedString(attributedString: self)
+        while let last = attributedString.string.unicodeScalars.last, characters.contains(last) {
+            attributedString.deleteCharacters(in: NSRange(location: attributedString.length - 1, length: 1))
+        }
+
+        return attributedString
+    }
+}


### PR DESCRIPTION
There is some performance issues with HTMLText, specifically with `NSMutableAttributedString` that triggers an immediate view render. The side-effect of that is an `AttributeGraph` cycle in SwiftUI causing unnecessary re-renders.

Also, using closure directly in dependencies (like `var`, or `@Environment`) results in view invalidation because a closure can not be Equatable and is not comparable efficiently. Using an id with an `Equatable` conformance remove these view invalidations on each passes.
