### PR TITLE
NE-1686 - [iOS] Improve article performance by changing HTML parse and add cache for html blocks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,9 +14,13 @@ let package = Package(
             targets: ["SwiftUIUtils"]
         ),
     ],
+    dependencies: [
+        .package(url: "https://github.com/Cocoanetics/DTCoreText.git", from: "1.6.0"),
+    ],
     targets: [
         .target(
             name: "SwiftUIUtils",
+            dependencies: ["DTCoreText"],
             path: "Sources"
         )
     ]

--- a/Sources/SwiftUI-Utils/View/HTMLText/HTMLText+Environment.swift
+++ b/Sources/SwiftUI-Utils/View/HTMLText/HTMLText+Environment.swift
@@ -1,5 +1,22 @@
 import SwiftUI
 
+public enum HTMLCacheConfiguration: Equatable {
+    case `default`
+    case custom(NSCache<NSString, NSAttributedString>)
+    case disabled
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.default, .default), (.disabled, .disabled):
+            return true
+        case let (.custom(lhsCache), .custom(rhsCache)):
+            return lhsCache === rhsCache
+        default:
+            return false
+        }
+    }
+}
+
 extension EnvironmentValues {
     @Entry var htmlForegroundColor: SwiftUI.Color = .black
     @Entry var htmlLineLimit: Int?
@@ -10,6 +27,7 @@ extension EnvironmentValues {
     @Entry var htmlAccessibilityTraits: UIAccessibilityTraits = .staticText
     @Entry var htmlTextAlignment: NSTextAlignment = .natural
     @Entry var htmlOpenURL: HTMLOpenURLAction? = nil
+    @Entry var htmlCacheConfiguration: HTMLCacheConfiguration = .default
 }
 
 struct HTMLOpenURLAction: Equatable {
@@ -61,5 +79,13 @@ extension View {
     
     public func onHTMLOpenURL(_ perform: @escaping (URL) -> Void) -> some View {
         environment(\.htmlOpenURL, HTMLOpenURLAction(handler: perform))
+    }
+
+    public func htmlCache(_ cache: NSCache<NSString, NSAttributedString>?) -> some View {
+        environment(\.htmlCacheConfiguration, cache.map { .custom($0) } ?? .default)
+    }
+
+    public func htmlCacheDisabled(_ disabled: Bool = true) -> some View {
+        environment(\.htmlCacheConfiguration, disabled ? .disabled : .default)
     }
 }

--- a/Sources/SwiftUI-Utils/View/HTMLText/HTMLText+Environment.swift
+++ b/Sources/SwiftUI-Utils/View/HTMLText/HTMLText+Environment.swift
@@ -1,19 +1,23 @@
 import SwiftUI
 
-public enum HTMLCacheConfiguration: Equatable {
-    case `default`
-    case custom(NSCache<NSString, NSAttributedString>)
-    case disabled
+public struct HTMLCacheConfiguration: Equatable {
+    let cache: NSCache<NSString, NSAttributedString>?
+
+    public static let `default`: HTMLCacheConfiguration = {
+        let cache = NSCache<NSString, NSAttributedString>()
+        cache.countLimit = 100
+        cache.name = "com.mirego.swiftui-utils.HTMLCache"
+        return HTMLCacheConfiguration(cache: cache)
+    }()
+
+    public static func custom(_ cache: NSCache<NSString, NSAttributedString>) -> HTMLCacheConfiguration {
+        HTMLCacheConfiguration(cache: cache)
+    }
+
+    public static var disabled = HTMLCacheConfiguration(cache: nil)
 
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        switch (lhs, rhs) {
-        case (.default, .default), (.disabled, .disabled):
-            return true
-        case let (.custom(lhsCache), .custom(rhsCache)):
-            return lhsCache === rhsCache
-        default:
-            return false
-        }
+        lhs.cache === rhs.cache
     }
 }
 

--- a/Sources/SwiftUI-Utils/View/HTMLText/HTMLText.swift
+++ b/Sources/SwiftUI-Utils/View/HTMLText/HTMLText.swift
@@ -18,22 +18,20 @@ public struct HTMLText: View {
     @Environment(\.htmlKerning) var kerning
     @Environment(\.htmlFont) var font
     @Environment(\.htmlLineSpacing) var lineSpacing
-    @Environment(\.htmlCache) var sharedCache
-    
+
     @StateObject var transformer = HTMLTransformer()
     @State var width: CGFloat?
-    
+
     let html: String
-    
+
     public init(html: String) {
         self.html = html
     }
-    
+
     public var body: some View {
         HTMLAttributedText(attributedString: transformer.html, availableWidth: width)
             .read(\.width, $width)
             .onAppear {
-                transformer.sharedCache = sharedCache
                 transformer.style = HTMLStyleSheet(font: font, lineSpacing: lineSpacing, kerning: kerning)
                 transformer.rawHTML = html
             }

--- a/Sources/SwiftUI-Utils/View/HTMLText/HTMLText.swift
+++ b/Sources/SwiftUI-Utils/View/HTMLText/HTMLText.swift
@@ -18,6 +18,7 @@ public struct HTMLText: View {
     @Environment(\.htmlKerning) var kerning
     @Environment(\.htmlFont) var font
     @Environment(\.htmlLineSpacing) var lineSpacing
+    @Environment(\.htmlCacheConfiguration) var cacheConfiguration
 
     @StateObject var transformer = HTMLTransformer()
     @State var width: CGFloat?
@@ -32,9 +33,11 @@ public struct HTMLText: View {
         HTMLAttributedText(attributedString: transformer.html, availableWidth: width)
             .read(\.width, $width)
             .onAppear {
+                transformer.cacheConfiguration = cacheConfiguration
                 transformer.style = HTMLStyleSheet(font: font, lineSpacing: lineSpacing, kerning: kerning)
                 transformer.rawHTML = html
             }
+            .onChange(of: cacheConfiguration) { transformer.cacheConfiguration = $0 }
             .onChange(of: font) { transformer.style.font = $0 }
             .onChange(of: lineSpacing) { transformer.style.lineSpacing = $0 }
             .onChange(of: kerning) { transformer.style.kerning = $0 }

--- a/Sources/SwiftUI-Utils/View/HTMLText/HTMLText.swift
+++ b/Sources/SwiftUI-Utils/View/HTMLText/HTMLText.swift
@@ -18,6 +18,7 @@ public struct HTMLText: View {
     @Environment(\.htmlKerning) var kerning
     @Environment(\.htmlFont) var font
     @Environment(\.htmlLineSpacing) var lineSpacing
+    @Environment(\.htmlCache) var sharedCache
     
     @StateObject var transformer = HTMLTransformer()
     @State var width: CGFloat?
@@ -32,6 +33,7 @@ public struct HTMLText: View {
         HTMLAttributedText(attributedString: transformer.html, availableWidth: width)
             .read(\.width, $width)
             .onAppear {
+                transformer.sharedCache = sharedCache
                 transformer.style = HTMLStyleSheet(font: font, lineSpacing: lineSpacing, kerning: kerning)
                 transformer.rawHTML = html
             }
@@ -90,7 +92,6 @@ extension HTMLAttributedText {
 
     class Coordinator: NSObject, UITextViewDelegate {
         private let logger = Logger(subsystem: "HTMLText", category: "Coordinator")
-        private var cached: (input: String, result: NSAttributedString?)?
 
         let parent: HTMLAttributedText
 

--- a/Sources/SwiftUI-Utils/View/HTMLText/HTMLTransformer.swift
+++ b/Sources/SwiftUI-Utils/View/HTMLText/HTMLTransformer.swift
@@ -3,15 +3,6 @@ import Foundation
 import SwiftUI
 import UIKit
 
-// Module-level cache - shared across all HTMLText views
-// NSCache auto-evicts under memory pressure (LRU-like behavior)
-private let sharedHTMLCache: NSCache<NSString, NSAttributedString> = {
-    let cache = NSCache<NSString, NSAttributedString>()
-    cache.countLimit = 100
-    cache.name = "com.mirego.swiftui-utils.HTMLCache"
-    return cache
-}()
-
 struct HTMLStyleSheet {
     var font: HTMLFont = .system
     var lineSpacing: CGFloat?
@@ -25,14 +16,7 @@ class HTMLTransformer: ObservableObject {
     var cacheConfiguration: HTMLCacheConfiguration = .default
 
     private var activeCache: NSCache<NSString, NSAttributedString>? {
-        switch cacheConfiguration {
-        case .default:
-            return sharedHTMLCache
-        case .custom(let cache):
-            return cache
-        case .disabled:
-            return nil
-        }
+        cacheConfiguration.cache
     }
 
     var style: HTMLStyleSheet = HTMLStyleSheet() {

--- a/SwiftUI-Utils.podspec
+++ b/SwiftUI-Utils.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
   spec.ios.deployment_target = "15.0"
   spec.swift_versions = "5.0"
+  spec.dependency 'DTCoreText'
 end

--- a/SwiftUI-Utils.podspec
+++ b/SwiftUI-Utils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name          = "SwiftUI-Utils"
-  spec.version       = "1.0.18"
+  spec.version       = "1.0.19"
   spec.summary       = "SwiftUI Utils library"
   spec.description   = "SwiftUI Utils is a library that contains several helpful components and extension methods to help you build the best SwiftUI apps."
   spec.homepage      = "https://github.com/mirego/swiftui-utils"


### PR DESCRIPTION
## Summary

  - Implemented module-level shared `NSCache` for parsed HTML in `HTMLText` component
  - Replaced slow `NSAttributedString` HTML parsing (~20-50ms) with DTCoreText (~0.5-1ms)
  - Cache persists across navigation, providing HITs when returning to previously viewed articles

  ## Problem

  HTML parsing in `HTMLText` was slow and repeated unnecessarily. Each time a user navigated between articles, the same content was re-parsed, causing CPU usage and potential UI jank.

  ## Solution

  | Metric | Before | After |
  |--------|--------|-------|
  | Parse time per paragraph | ~20-50ms | ~0.5-1ms |
  | Navigate back to article | Re-parse all | Cache HIT |
  | Memory management | N/A | Auto-evict (LRU) at 100 items |

  ## Implementation Details

  - **Module-level cache**: Shared across all `HTMLText` views so cache survives navigation
  - **NSCache**: Auto-evicts under memory pressure with LRU-like behavior
  - **Cache key**: `contentHash_fontName_fontSize_lineSpacing_kerning`
  - **Limit**: 100 paragraphs (a typical article has between 3 and 10 paragraphs) meaning we will cache html of minimum 10 articles)

  ## Why module-level instead of per-view?

  Per-view caches were ineffective because SwiftUI recreates views when navigating in a pager. A shared cache ensures previously viewed articles get cache HITs when the user navigates back.

## TEST logs to see if cache works
[test.txt](https://github.com/user-attachments/files/24441513/test.txt)

