### PR TITLE
Change onVisibleViewIdentifiersChange scope

### DIFF
--- a/Sources/SwiftUI-Utils/ScrollView/VisibleViewGetters.swift
+++ b/Sources/SwiftUI-Utils/ScrollView/VisibleViewGetters.swift
@@ -12,7 +12,7 @@ extension View {
     }
 }
 
-extension ScrollView {
+extension View {
     public func onVisibleViewIdentifiersChange(_ items: @escaping ([String]) -> Void) -> some View {
         backgroundPreferenceValue(LoadedItemsPreferenceKey.self) { loadedItems in
             ReadVisibleItemView(loadedItems: loadedItems)

--- a/SwiftUI-Utils.podspec
+++ b/SwiftUI-Utils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name          = "SwiftUI-Utils"
-  spec.version       = "1.0.19"
+  spec.version       = "1.0.20"
   spec.summary       = "SwiftUI Utils library"
   spec.description   = "SwiftUI Utils is a library that contains several helpful components and extension methods to help you build the best SwiftUI apps."
   spec.homepage      = "https://github.com/mirego/swiftui-utils"


### PR DESCRIPTION
Change the visibility of the `onVisibleViewIdentifiersChange` extension to be available to every `View` as restricting it to `ScrollView` was not necessary.